### PR TITLE
use the sample time in Meter to provide accurate rate and mean rate estimates

### DIFF
--- a/spec/unit/formatter/byte_rate_spec.rb
+++ b/spec/unit/formatter/byte_rate_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe TTY::ProgressBar, ':byte_rate token' do
     time_now = Time.local(2014, 10, 5, 12, 0, 0)
     Timecop.freeze(time_now)
     progress = TTY::ProgressBar.new(":byte_rate", output: output, total: 10000, interval: 1)
+    # Generate a serie of advances at 2s intervals
+    #   t+0     advance=0         total=0
+    #   t+2     advance=1000      total=1000
+    #   t+4     advance=2000      total=3000
+    #   t+6     advance=3000      total=6000
+    #   t+8     advance=4000      total=10_000
+    # NOTE: mean_byte uses 1024 for the scale in K, M ...
     5.times do |i|
       time_now = Time.local(2014, 10, 5, 12, 0, i * 2)
       Timecop.freeze(time_now)
@@ -16,11 +23,11 @@ RSpec.describe TTY::ProgressBar, ':byte_rate token' do
     end
     output.rewind
     expect(output.read).to eq([
-      "\e[1G0.0B",
+      "\e[1G0B",
+      "\e[1G500.0B",
       "\e[1G1000.0B",
-      "\e[1G1.95KB",
-      "\e[1G2.93KB",
-      "\e[1G3.91KB\n"
+      "\e[1G1.46KB",
+      "\e[1G1.95KB\n"
     ].join)
     Timecop.return
   end

--- a/spec/unit/formatter/mean_byte_spec.rb
+++ b/spec/unit/formatter/mean_byte_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe TTY::ProgressBar, ':mean_byte token' do
     time_now = Time.local(2014, 10, 5, 12, 0, 0)
     Timecop.freeze(time_now)
     progress = TTY::ProgressBar.new(":mean_byte", output: output, total: 10000, interval: 1)
+    # Generate a serie of advances at 2s intervals
+    #   t+0     advance=0         total=0
+    #   t+2     advance=1000      total=1000
+    #   t+4     advance=2000      total=3000
+    #   t+6     advance=3000      total=6000
+    #   t+8     advance=4000      total=10_000
+    # NOTE: mean_byte uses 1024 for the scale in K, M ...
     5.times do |i|
       time_now = Time.local(2014, 10, 5, 12, 0, i * 2)
       Timecop.freeze(time_now)
@@ -16,11 +23,11 @@ RSpec.describe TTY::ProgressBar, ':mean_byte token' do
     end
     output.rewind
     expect(output.read).to eq([
-      "\e[1G0.0B",
+      "\e[1G0B",
       "\e[1G500.0B",
+      "\e[1G750.0B",
       "\e[1G1000.0B",
-      "\e[1G1.46KB",
-      "\e[1G1.95KB\n"
+      "\e[1G1.22KB\n"
     ].join)
     Timecop.return
   end

--- a/spec/unit/formatter/mean_rate_spec.rb
+++ b/spec/unit/formatter/mean_rate_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe TTY::ProgressBar, ':mean_rate token' do
     time_now = Time.local(2014, 10, 5, 12, 0, 0)
     Timecop.freeze(time_now)
     progress = TTY::ProgressBar.new(":mean_rate", output: output, total: 100, interval: 1)
+    # Generate a serie of advances at 2s intervals
+    #   t+0     advance=0       total=0
+    #   t+2     advance=10      total=10
+    #   t+4     advance=20      total=30
+    #   t+6     advance=30      total=60
+    #   t+8     advance=40      total=100
     5.times do |i|
       time_now = Time.local(2014, 10, 5, 12, 0, i * 2)
       Timecop.freeze(time_now)
@@ -18,9 +24,9 @@ RSpec.describe TTY::ProgressBar, ':mean_rate token' do
     expect(output.read).to eq([
       "\e[1G 0.00",
       "\e[1G 5.00",
+      "\e[1G 7.50",
       "\e[1G10.00",
-      "\e[1G15.00",
-      "\e[1G20.00\n"
+      "\e[1G12.50\n"
     ].join)
     Timecop.return
   end

--- a/spec/unit/formatter/rate_spec.rb
+++ b/spec/unit/formatter/rate_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe TTY::ProgressBar, ':rate token' do
     time_now = Time.local(2014, 10, 5, 12, 0, 0)
     Timecop.freeze(time_now)
     progress = TTY::ProgressBar.new(":rate", output: output, total: 100, interval: 1)
+    # Generate a serie of advances at 2s intervals
+    #   t+0     advance=0       total=0
+    #   t+2     advance=10      total=10
+    #   t+4     advance=20      total=30
+    #   t+6     advance=30      total=60
+    #   t+8     advance=40      total=100
     5.times do |i|
       time_now = Time.local(2014, 10, 5, 12, 0, i * 2)
       Timecop.freeze(time_now)
@@ -17,10 +23,10 @@ RSpec.describe TTY::ProgressBar, ':rate token' do
     output.rewind
     expect(output.read).to eq([
       "\e[1G 0.00",
+      "\e[1G 5.00",
       "\e[1G10.00",
-      "\e[1G20.00",
-      "\e[1G30.00",
-      "\e[1G40.00\n"
+      "\e[1G15.00",
+      "\e[1G20.00\n"
     ].join)
     Timecop.return
   end

--- a/spec/unit/meter_spec.rb
+++ b/spec/unit/meter_spec.rb
@@ -8,62 +8,45 @@ RSpec.describe TTY::ProgressBar::Meter, '#rate' do
 
   it "measures rate per second" do
     meter = TTY::ProgressBar::Meter.new(1)
+    start_time = Time.at(10, 0)
+    Timecop.freeze(start_time)
     meter.start
-    time_now = Time.local(2014, 10, 5, 12, 0, 0)
-    Timecop.freeze(time_now)
 
     # First sample batch
-    time_now = Time.local(2014, 10, 5, 12, 0, 0, 100)
-    meter.sample time_now, 1000
-    expect(meter.rate).to eq(1000)
-    expect(meter.mean_rate).to eq(1000)
+    meter.sample Time.at(10, 100_000), 5
+    expect(meter.rate).to eq(50)
+    expect(meter.mean_rate).to eq(50)
 
-    time_now = Time.local(2014, 10, 5, 12, 0, 0, 200)
-    meter.sample time_now, 2000
-    expect(meter.rate).to eq(1500)
-    expect(meter.mean_rate).to eq(1500)
+    meter.sample Time.at(10, 500_000), 5
+    expect(meter.rate).to eq(20)
+    expect(meter.mean_rate).to eq(20)
 
-    time_now = Time.local(2014, 10, 5, 12, 0, 0, 300)
-    meter.sample time_now, 1000
-    expect(meter.rate).to be_within(0.5).of(1333)
-    expect(meter.mean_rate).to be_within(0.5).of(1333)
+    meter.sample Time.at(11, 000_000), 5
+    expect(meter.rate).to eq(15)
+    expect(meter.mean_rate).to eq(15)
 
-    # Second sample batch after 1s
-    time_now = Time.local(2014, 10, 5, 12, 0, 1, 400)
-    meter.sample time_now, 500
-    expect(meter.rate).to eq(500)
-    expect(meter.mean_rate).to eq(2250)
+    meter.sample Time.at(11, 500_000), 5
+    expect(meter.rate).to eq(10)
+    expect(meter.mean_rate).to be_within(0.001).of(13.333)
 
-    time_now = Time.local(2014, 10, 5, 12, 0, 1, 500)
-    meter.sample time_now, 500
-    expect(meter.rate).to eq(500)
-    expect(meter.mean_rate).to eq(2500)
-
-    # Third sample batch after 3s
-    time_now = Time.local(2014, 10, 5, 12, 0, 2, 600)
-    meter.sample time_now, 3000
-    expect(meter.rate).to eq(3000)
-    expect(meter.mean_rate).to be_within(0.7).of(2666)
-
-    time_now = Time.local(2014, 10, 5, 12, 0, 2, 700)
-    meter.sample time_now, 3000
-    expect(meter.rate).to eq(3000)
-    expect(meter.mean_rate).to be_within(0.7).of(3666)
+    meter.sample Time.at(12, 000_000), 10
+    expect(meter.rate).to eq(15)
+    expect(meter.mean_rate).to eq(15)
   end
 
   it "clears measurements" do
     meter = TTY::ProgressBar::Meter.new(1)
+    start_time = Time.at(10, 0)
+    Timecop.freeze(start_time)
     meter.start
-    time_now = Time.local(2014, 10, 5, 12, 0, 0)
-    Timecop.freeze(time_now)
 
     time_now = Time.local(2014, 10, 5, 12, 0, 0, 100)
-    meter.sample time_now, 1000
-    expect(meter.rates).to eq([1000])
+    meter.sample start_time + 1, 1000
+    expect(meter.rates).to eq([1000, 1000])
     expect(meter.rate).to eq(1000)
 
     meter.clear
-    expect(meter.rates).to eq([])
+    expect(meter.rates).to eq([0])
     expect(meter.rate).to eq(0)
   end
 end


### PR DESCRIPTION
The current rates were completely broken if the sampling was not regular.
This code uses the sample time (as given to Meter#sample) to compute
the actual rate.