### PR TITLE
Do not reset multibar state

### DIFF
--- a/lib/tty/progressbar.rb
+++ b/lib/tty/progressbar.rb
@@ -80,6 +80,10 @@ module TTY
 
       @formatter.load
       reset
+
+      @first_render = true
+      @multibar     = nil
+      @row          = nil
     end
 
     # Reset progress to default configuration
@@ -96,9 +100,6 @@ module TTY
       @start_at          = Time.now
       @started           = false
       @tokens            = {}
-      @multibar          = nil
-      @row               = nil
-      @first_render      = true
 
       @meter.clear
     end

--- a/spec/unit/reset_spec.rb
+++ b/spec/unit/reset_spec.rb
@@ -28,4 +28,29 @@ RSpec.describe TTY::ProgressBar, '#reset' do
       "\e[1G[======    ]"
     ].join)
   end
+
+  it "leaves multibar state alone" do
+    main = TTY::ProgressBar::Multi.new("", output: output, total: 10)
+    progress = main.register("[:bar]")
+    progress.advance(10)
+    expect(progress.complete?).to be(true)
+    progress.reset
+    expect(progress.complete?).to be(false)
+    progress.advance(10)
+    output.rewind
+
+    top    = TTY::ProgressBar::Multi::DEFAULT_INSET[:top]
+    bottom = TTY::ProgressBar::Multi::DEFAULT_INSET[:bottom]
+
+    progress_updates =
+      output.read.scan(/#{Regexp.escape top}|#{Regexp.escape bottom}/)
+    expect(progress_updates.shift).to match(top)
+    expect(progress_updates.shift).to match(bottom)
+    expect(progress_updates.shift).to match(bottom)
+    expect(progress_updates.shift).to match(top)
+    expect(progress_updates.shift).to match(bottom)
+    expect(progress_updates.shift).to match(bottom)
+
+    expect(progress_updates).to be_empty
+  end
 end


### PR DESCRIPTION
I want to use the multibar with docker image push and pull.  The image
push and pull progress shows information for many layers with many
different states.  The same layer will transition through download wait,
downloading, verifying, extract wait, extracting, then completed states

For the downloading and extracting states of a layer I wish to re-use
the same progress bar location in the multibar, but with a different
title.  I can accomplish this with a single progress bar with code like
the following:

	bar = TTY::ProgressBar.new "downloading [:bar] :eta", ...

	bar.start

	n.times do
	  sleep 0.1
	  bar.advance 1
	end

	bar.format.replace "extracting  [:bar] :eta"

	bar.reset

	n.times do
	  sleep 0.1
	  bar.advance 1
	end

This stretches the API of the progress bar a bit by using
String#replace, but otherwise appears to be all-OK for the intended use
of the API.

This does not work with the multibar as the rendering information is
reset.

The documentation says:

> In order to reset currently running or finished progress bar to its
> original configuration and initial position use reset

Since I created the bar I wish to reset through
TTY::ProgressBar::Multi#register I expect the "original configuration" to
include the multibar rendering configuration.

This was not the case.  In #1 the entire configuration is reset
including the multibar rendering configuration.  This means the bars I
reset to show a new stage do not render as part of a multibar.

In order to allow my expected behavior the multibar rendering state
setup is moved to ProgressBar#initialize and never reset.  The only way
to configure a ProgressBar to render as a multi-bar is through
Multi#register and ProgressBar#attach_to (another way to create a
multi-bar), so this seems OK.