### PR TITLE
Pad formatted output when it gets shorter

### DIFF
--- a/lib/tty/progressbar.rb
+++ b/lib/tty/progressbar.rb
@@ -257,7 +257,10 @@ module TTY
       @tokens.each do |token, val|
         formatted = formatted.gsub(":#{token}", val)
       end
-      write(formatted, true)
+
+      padded = padout(formatted)
+
+      write(padded, true)
 
       @last_render_time  = Time.now
       @last_render_width = display_columns(formatted)
@@ -479,8 +482,10 @@ module TTY
     #
     # @api private
     def padout(message)
-      if @last_render_width > message.length
-        remaining_width = @last_render_width - message.length
+      message_length = display_columns(message)
+
+      if @last_render_width > message_length
+        remaining_width = @last_render_width - message_length
         message += ' ' * remaining_width
       end
       message

--- a/spec/unit/custom_token_spec.rb
+++ b/spec/unit/custom_token_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TTY::ProgressBar, 'custom token' do
     output.rewind
     expect(output.read).to eq([
       "\e[1G(1) Hello Piotr!",
-      "\e[1G(4) Bye Piotr!\n"
+      "\e[1G(4) Bye Piotr!  \n"
     ].join)
   end
 end

--- a/spec/unit/render_spec.rb
+++ b/spec/unit/render_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe TTY::ProgressBar, "#render" do
+  let(:output) { StringIO.new("", "w+") }
+
+  it "pads out longer previous lines" do
+    progress = TTY::ProgressBar.new ":current_byte" do |config|
+      config.no_width = true
+      config.output   = output
+      config.total    = 1_048_577
+    end
+
+    progress.advance(1)
+    progress.advance(1_048_574)
+    progress.advance(1)
+    progress.advance(1)
+
+    output.rewind
+
+    expect(output.read).to eq([
+      "\e[1G1B",
+      "\e[1G1024.00KB", # must not pad, line is longer
+      "\e[1G1.00MB   ", # must pad out "0KB"
+      "\e[1G1.00MB",    # must not pad, line is equal
+    ].join)
+  end
+end

--- a/spec/unit/resize_spec.rb
+++ b/spec/unit/resize_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TTY::ProgressBar, '#resize' do
       "\e[1G[==        ]",
       "\e[1G[====      ]",
       "\e[0m\e[2K\e[1G",
-      "\e[1G[===  ]",
+      "\e[1G[===  ]     ",
       "\e[1G[==== ]",
       "\e[1G[=====]\n"
     ].join)


### PR DESCRIPTION
When using the CurrentByte formatter the rendered progress bar may get
shorter.  When the current values advances from under 1MB to over 1MB
the bar should show "1024.00KB" then "1.00MB".

The output was not padded so the end result on the screen would look
like "1.00MB0KB" which was not easy to read and does not look nice.

Now the output is padded so the characters left over from the last
render are replaced by spaces so the result on the screen will look like
"1.00MB".

To accomplish this the existing ProgressBar#padout method is called from
ProgressBar#render and #padout is updated to use
ProgressBar#display_columns so the next render width is correctly
calculated.