### PR TITLE
Always restore hidden cursor

### DIFF
--- a/lib/tty/progressbar.rb
+++ b/lib/tty/progressbar.rb
@@ -354,10 +354,6 @@ module TTY
     #
     # @api public
     def finish
-      # reenable cursor if it is turned off
-      if hide_cursor && @last_render_width != 0
-        write(TTY::Cursor.show, false)
-      end
       return if done?
       @current = total unless no_width
       render
@@ -365,6 +361,12 @@ module TTY
     ensure
       @meter.clear
       @done = true
+
+      # reenable cursor if it is turned off
+      if hide_cursor && @last_render_width != 0
+        write(TTY::Cursor.show, false)
+      end
+
       emit(:done)
     end
 

--- a/spec/unit/hide_cursor_spec.rb
+++ b/spec/unit/hide_cursor_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TTY::ProgressBar, '#hide_cursor' do
       "\e[1G[==   ]",
       "\e[1G[===  ]",
       "\e[1G[==== ]",
-      "\e[?25h\e[1G[=====]\n"
+      "\e[1G[=====]\n\e[?25h"
     ].join)
   end
 
@@ -22,6 +22,6 @@ RSpec.describe TTY::ProgressBar, '#hide_cursor' do
     progress.advance(6)
     expect(progress.complete?).to eq(true)
     output.rewind
-    expect(output.read).to eq("\e[1G[=====]\n")
+    expect(output.read).to eq("\e[1G[=====]\n\e[?25h")
   end
 end


### PR DESCRIPTION
Through some subtleties it is possible for the progress bar to not
restore the cursor:

    b = TTY::ProgressBar.new "stuff |:bar|",
                             hide_cursor: true,
                             no_width: true,
                             total: 5,
                             width: 5

    b.finish

Prior to this commit when #finish executes it will not restore the
cursor.

Tracing through #finish, while `hide_cursor` is true, we skip restoring
the cursor because the last render width is still 0 as we have not
rendered.  We haven't completed the progress bar so we are not #done?.
We then #render.

In #render we are still not #done? so we hide the cursor because
`hide_cursor` is true, our last render width is still zero, and the
current value is not the total.

This leaves the cursor hidden when we exit the program.

This commit moves cursor restoration to the ensure block of finish so it
should always run, even if we are #done?