### PR TITLE
fix progress bar erroring when the amount of completed work is 0

### DIFF
--- a/lib/tty/progressbar/formatter/bar.rb
+++ b/lib/tty/progressbar/formatter/bar.rb
@@ -46,7 +46,7 @@ module TTY
 
         complete   = Array.new(complete_items, @progress.complete)
         incomplete = Array.new(incomplete_items, @progress.incomplete)
-        complete[-1] = @progress.head if complete_bar_length > 0
+        complete[-1] = @progress.head if complete_bar_length > 0 && complete.size.positive?
 
         bar = ''
         bar += complete.join

--- a/spec/unit/formatter/bar_spec.rb
+++ b/spec/unit/formatter/bar_spec.rb
@@ -1,3 +1,4 @@
+require 'pastel'
 RSpec.describe TTY::ProgressBar, ':bar token' do
   let(:output) { StringIO.new('', 'w+') }
 
@@ -12,5 +13,15 @@ RSpec.describe TTY::ProgressBar, ':bar token' do
       "\e[1G[==== ]",
       "\e[1G[=====]\n"
     ].join)
+  end
+
+  it "properly handles the case of a large amount of work on a small bar that has colors for complete" do
+    pastel = Pastel.new
+    progress = TTY::ProgressBar.new("[:bar]",
+      total: 1000,
+      complete: pastel.on_green(' '),
+      width: 80
+    )
+    expect{ 5.times { progress.advance(20) } }.to_not raise_error
   end
 end

--- a/tty-progressbar.gemspec
+++ b/tty-progressbar.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'timecop', '~> 0.9.1'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'pastel'
 end


### PR DESCRIPTION
Currently there seems to be an issue with advancing progress bars that have colors in them, where it raises an `IndexError` because the last value of the `complete` array is trying to be set, but the array itself is of size 0.

This pr fixes this and also adds a test case for this. It seems to fully work for my usecases, but if there's something I've missed that would cause this to not work, please let me know and I'll be more than happy to fix it!