### PR TITLE
Fix #37

### DIFF
--- a/lib/tty/progressbar.rb
+++ b/lib/tty/progressbar.rb
@@ -371,6 +371,14 @@ module TTY
       emit(:done)
     end
 
+    # Continue rendering if after bar is done total number is updated
+    #
+    # @api public
+    def continue
+      @done = false
+      @stopped = false
+    end
+
     # Stop and cancel the progress at the current position
     #
     # @api public

--- a/lib/tty/progressbar/multi.rb
+++ b/lib/tty/progressbar/multi.rb
@@ -79,6 +79,7 @@ module TTY
           observe(bar) if observable
           if @top_bar
             @top_bar.update(total: total)
+            @top_bar.continue
             @top_bar.update(width: total) unless @width
           end
         end


### PR DESCRIPTION
### Describe the change
Fixes #37 
Adds a public method to reset `@done` and `@stopped`.

### Why are we doing this?
On multi bars if we are adding new bars dynamically, the top bar is going to finished (`@done?` will return true) after the first registered bar is done.
`register` method increases the total of `@top_bar` but `@done` remains set to `true` and that why it does not render anymore even though we add new bars.

### Benefits
Fixes multiple bars with dynamically registered bars.

### Drawbacks
Shouldn't be any

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
