### PR TITLE
Handle #total with indeterminate children in MultiBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+* Fix NoMethodError when MultiBar registers indeterminate children (issue #49)
+
 ## [v0.18.1] - 2021-01-25
 
 ### Fixed

--- a/lib/tty/progressbar/multi.rb
+++ b/lib/tty/progressbar/multi.rb
@@ -142,7 +142,7 @@ module TTY
       # @api public
       def total
         synchronize do
-          (@bars - [@top_bar]).map(&:total).reduce(&:+)
+          (@bars - [@top_bar]).map(&:total).compact.reduce(&:+)
         end
       end
 

--- a/spec/unit/multi/advance_spec.rb
+++ b/spec/unit/multi/advance_spec.rb
@@ -122,4 +122,53 @@ RSpec.describe TTY::ProgressBar::Multi, "advance" do
       restore
     ].join)
   end
+
+  it "advances progress bars correctly with indeterminate children" do
+    bars = described_class.new("total: :current", output: output)
+
+    bar1 = bars.register("one: :current")
+    bar2 = bars.register("two: :current")
+
+    bar1.advance
+
+    output.rewind
+    expect(output.read).to eq([
+      "\e[1G#{top}total: 1\n",
+      "\e[1G#{bottom}one: 1\n"
+    ].join)
+
+    bar2.advance
+
+    output.rewind
+    expect(output.read).to eq([
+      "\e[1G#{top}total: 1\n",
+      "\e[1G#{bottom}one: 1\n",
+      save,
+      "\e[2A", # up 2 lines
+      "\e[1G#{top}total: 2",
+      restore,
+      "\e[1G#{bottom}two: 1\n"
+    ].join)
+
+    bar1.advance
+
+    output.rewind
+    expect(output.read).to eq([
+      "\e[1G#{top}total: 1\n",
+      "\e[1G#{bottom}one: 1\n",
+      save,
+      "\e[2A", # up 2 lines
+      "\e[1G#{top}total: 2",
+      restore,
+      "\e[1G#{bottom}two: 1\n",
+      save,
+      "\e[3A", # up 3 lines
+      "\e[1G#{top}total: 3",
+      restore,
+      save,
+      "\e[2A", # up 2 lines
+      "\e[1G#{middle}one: 2",
+      restore
+    ].join)
+  end
 end

--- a/spec/unit/multi/register_spec.rb
+++ b/spec/unit/multi/register_spec.rb
@@ -35,4 +35,22 @@ RSpec.describe TTY::ProgressBar::Multi, "#register" do
     expect(bars.total).to eq(15)
     expect(bars.current).to eq(0)
   end
+
+  it "updates total based on children totals" do
+    bars = TTY::ProgressBar::Multi.new("main [:bar]", output: output)
+
+    bars.register("[:bar]", total: 1)
+    expect(bars.total).to eq(1)
+
+    bars.register("[:bar]", total: 1)
+    expect(bars.total).to eq(2)
+  end
+
+  it "can register indeterminate children" do
+    bars = TTY::ProgressBar::Multi.new("main [:bar]", output: output)
+    bars.register("[:bar]")
+    bars.register("[:bar]")
+
+    expect(bars.total).to eq(nil)
+  end
 end


### PR DESCRIPTION
### Describe the change
Avoids `NoMethodError` (`nil + other`) when calculating `#total` for `TTY::ProgressBar::Multi` with indeterminate children bars.

Fixes #49

### Why are we doing this?
When calling `TTY::ProgressBar::Multi#register`, the `@top_bar` `@total`  is updated by summing the children bars' `total`. If a child bar is indeterminate, its total is `nil`. Calling `nil + other` raises `NoMethodError`.

### Benefits
You can do neat things like track the progress of multiple indeterminate sub tasks while seeing the total progress as well without raising an exception.

### Drawbacks
It adds a `compact` method call to remove `nil` `totals`.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[NA] Documentaion updated?
