### PR TITLE
Fix setting the current progress for an indeterminate bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+* Fix setting the current progress for an indeterminate bar by Alex Watt
+  (@alexcwatt)
+
 ## [v0.18.2] - 2021-03-08
 
 ### Fixed

--- a/lib/tty/progressbar.rb
+++ b/lib/tty/progressbar.rb
@@ -290,7 +290,12 @@ module TTY
     #
     # @api public
     def current=(value)
-      value = [0, [value, total].min].max
+      unless value.is_a?(Numeric)
+        raise ArgumentError, "Expected a numeric value, " \
+                             "got #{value.inspect} instead."
+      end
+
+      value = [0, [value, total].compact.min].max
       advance(value - @current)
     end
 

--- a/spec/unit/set_current_spec.rb
+++ b/spec/unit/set_current_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe TTY::ProgressBar, "#current=" do
     expect(progress.current).to eq(0)
   end
 
+  it "doesn't allow nil" do
+    progress = TTY::ProgressBar.new("[:bar]", output: output, total: 10)
+    expect {
+      progress.current = nil
+    }.to raise_error(
+      ArgumentError,
+      "Expected a numeric value, got nil instead."
+    )
+    expect(progress.current).to eq(0)
+  end
+
   it "cannot backtrack on finished" do
     progress = TTY::ProgressBar.new("[:bar]", output: output, total: 10)
     progress.current = 10
@@ -41,5 +52,11 @@ RSpec.describe TTY::ProgressBar, "#current=" do
     expect(progress.current).to eq(10)
     output.rewind
     expect(output.read).to eq("\e[1G[==========]\n")
+  end
+
+  it "allows setting progress when the total is unknown" do
+    progress = TTY::ProgressBar.new("[:bar]", output: output, total: nil)
+    progress.current = 5
+    expect(progress.current).to eq(5)
   end
 end


### PR DESCRIPTION
### Describe the change

I noticed that `#current=` failed for indeterminate progress bars. The primary test I added would error like this:

```
     ArgumentError:
       comparison of NilClass with 5 failed
```

I added a new `ArgumentError` guard to also preserve the existing, desirable, behavior of not supporting `#current = nil`, and a test to cover this. Note that `current = nil` was already raising `ArgumentError` in both the determinate and indeterminate cases (`comparison of Integer with nil failed`, `comparison of NilClass with 0 failed`, etc.); now the error message is one that we set.

### Why are we doing this?

As far as I can tell, there's no reason that `current =` shouldn't work for indeterminate progress bars. It seems that indeterminate progress bars are meant to have a `current` value, and can have it by calling `.advance`, so adding support seems consistent with the rest of the library.

### Benefits

It's quite nice to be able to set current progress for indeterminate progress bars!

### Drawbacks

I don't have any to highlight.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [ ] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [x] Changelog updated?
