### PR TITLE
Update unicode-display_width dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 ### Changes
-* Relaxed versions constraints for unicode-display_width dependency
+* Relaxed version constraints for unicode-display_width dependency
 
 ## [v0.18.3] - 2024-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## unreleased
 
 ### Changed
-* Relaxed version constraints for unicode-display_width dependency
+* Change the gemspec to allow version 3 of unicode-display_width dependency
+  by Kieran Pilkington (@KieranP) 
 
 ## [v0.18.3] - 2024-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-### Changes
+### Changed
 * Relaxed version constraints for unicode-display_width dependency
 
 ## [v0.18.3] - 2024-11-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## unreleased
+
+### Changes
+* Relaxed versions constraints for unicode-display_width dependency
+
 ## [v0.18.3] - 2024-11-10
 
 ### Fixed

--- a/tty-progressbar.gemspec
+++ b/tty-progressbar.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "strings-ansi", "~> 0.2"
   spec.add_dependency "tty-cursor", "~> 0.7"
   spec.add_dependency "tty-screen", "~> 0.8"
-  spec.add_dependency "unicode-display_width", ">= 1.6", "< 3.0"
+  spec.add_dependency "unicode-display_width", ">= 2.4.0", "< 4.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0"

--- a/tty-progressbar.gemspec
+++ b/tty-progressbar.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "strings-ansi", "~> 0.2"
   spec.add_dependency "tty-cursor", "~> 0.7"
   spec.add_dependency "tty-screen", "~> 0.8"
-  spec.add_dependency "unicode-display_width", ">= 2.4.0", "< 4.0"
+  spec.add_dependency "unicode-display_width", ">= 1.6", "< 4.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
### Describe the change

Support using v3 of unicode-display_width

### Why are we doing this?

Inline with rubocop requirements, so that we're not forcing users to downgrade

### Benefits

Allow users of tty-progressbar to use latest gem versions

### Drawbacks

None known

### Requirements
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
