### PR TITLE
Add support for :nerdfont based :bar_format symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## unreleased 
+
+### Added
+* Add :nerdfont as a new supported :bar_format option
+
 ## [v0.18.3] - 2024-11-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ There are number of preconfigured bar formats you can choose from.
 | `:diamond` | `♦♦♦♦♦♢♢♢♢♢` | `♢♦♢`         |
 | `:dot`     | `･･････････` | `･･･`         |
 | `:heart`   | `♥♥♥♥♥♡♡♡♡♡` | `♡♥♡`         |
+| `:nerdfont`| ``| ``         |
 | `:rectangle` | `▮▮▮▮▮▯▯▯▯▯` | `▯▮▯`       |
 | `:square`  | `▪▪▪▪▪▫▫▫▫▫` | `▫▪▫`         |
 | `:star`    | `★★★★★☆☆☆☆☆` | `☆★☆`         |

--- a/lib/tty/progressbar/formats.rb
+++ b/lib/tty/progressbar/formats.rb
@@ -79,6 +79,11 @@ module TTY
           incomplete: "♡",
           unknown: "♡♥♡"
         },
+        nerdfont: { # 
+          complete: "",
+          incomplete: "",
+          unknown: ""
+        },
         rectangle: { # ▮▮▮▮▮▯▯▯▯▯
           complete: "▮",
           incomplete: "▯",

--- a/spec/unit/new_spec.rb
+++ b/spec/unit/new_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe TTY::ProgressBar, ".new" do
       "unsupported bar format: :unknown. Available formats are: " \
       ":arrow, :asterisk, :blade, :block, :box, :bracket, " \
       ":burger, :button, :chevron, :circle, :classic, :crate, :diamond, :dot, " \
-      ":heart, :rectangle, :square, :star, :track, :tread, :triangle, :wave"
+      ":heart, :nerdfont, :rectangle, :square, :star, :track, "\
+      ":tread, :triangle, :wave"
     )
   end
 


### PR DESCRIPTION
### Describe the change

Adds Nerdfont based bar_format symbols

### Why are we doing this?

Nerdfont based progress bar is a popular format.

Here is how it looks like: 

<img width="110" height="31" alt="image" src="https://github.com/user-attachments/assets/d7ab6089-d6eb-4929-bdcc-ef95bdde355e" />


### Benefits
How will the library improve?

### Drawbacks
Possible drawbacks applying this change.

Requires a Nerdfont patched font to be able to see it.

The format doesn't allow for specifying right and left corners, so it can't look fully complete as in the example below:

<img width="129" height="38" alt="image" src="https://github.com/user-attachments/assets/4d92538e-86c1-46c7-916d-ed2eab0aaa45" />

I'm happy to implement additional support for that (requires four new optional style options, something on the lines of : `start_incomplete`, `start_complete`, `end_incomplete` `end_complete`. See https://www.nerdfonts.com/cheat-sheet (search for `nf-extra-progress`)

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
